### PR TITLE
Switch the PR workflow to use GH-provided runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-test-workflow:
     name: B&T
-    runs-on: [self-hosted, macOS, macos13]
+    runs-on: [macos-13]
     steps:
     - uses: actions/checkout@v3.5.3
     - name: Run build_and_test.sh


### PR DESCRIPTION
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

We need to stop running TetraRT's CI on our self-hosted machines. It's a security hole, anyone can fork the repository and submit a pull request that runs malicious code on our runners.